### PR TITLE
Show correct `Pkg.clone` command for unregistered packages

### DIFF
--- a/app/views/packages/show.html.erb
+++ b/app/views/packages/show.html.erb
@@ -78,9 +78,12 @@
       <%
         package_command = \
           @package.is_registered ? 'add' : 'clone'
+        
+        package_reference = \
+          @package.is_registered ? @package.name : @package.url
       %>
 
-      <h4 class="cs-no-margin">Pkg.<%= package_command %>("<%= @package.name %>")</h4>
+      <h4 class="cs-no-margin">Pkg.<%= package_command %>("<%= package_reference %>")</h4>
     </div>
 
     <div class="panel-body cs-no-padding">


### PR DESCRIPTION
I think this is the correct code but I've never used eRuby before and I haven't seen the output so I might have done something wrong. 

Before this, it would show `Pkg.clone("ThePackage")` which, if you didn't have it installed, would create a new empty git repo. 